### PR TITLE
Added mitigiation for devcontainer use on Apple silicone

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:jammy

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,8 @@
 	"name": "Ubuntu",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	// If using Apple Silicone (tested on M1) use the below Dockerfile instead of the above image
+	//"dockerFile": "Dockerfile"
 	"features": {
 		"ghcr.io/jarrodcolburn/features/flutter-sdk:0": {}
 	},


### PR DESCRIPTION
Added commented alternative to the default image provided by the devcontainer. 

On an Apple M1 processor, it looks like the Apple rosetta emulator defaults to arm64 for containers (understandably so). This causes the container to fail do to an inability to read elf files targeting intel-based processors. Forcing the rosetta emulator to point at amd64 allows the devcontainer to function as expected on Docker Engine running on Apple M1 processor.